### PR TITLE
Scala 2.10.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
+  - 2.10.6
   - 2.11.8
   - 2.12.0
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import UnidocKeys.{ unidocProjectFilter, unidoc }
 lazy val baseSettings = Seq(
   organization := "io.rbricks",
   scalaVersion := "2.12.0",
-  crossScalaVersions := Seq("2.11.8", "2.12.0"),
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
   version := "0.3-SNAPSHOT"
 )
 


### PR DESCRIPTION
This allows cross-building with 2.10 with no code change.

Motivation: I'd like to switch to scalog in [libisabelle](https://github.com/larsrh/libisabelle), but because libisabelle is a dependency of an SBT plugin, I need to support 2.10.